### PR TITLE
Use a new context in save requests with a configurable timeout

### DIFF
--- a/options.go
+++ b/options.go
@@ -120,3 +120,10 @@ func RefreshCookies() Option {
 		s.refreshCookies = true
 	}
 }
+
+// SaveTimeout sets the timeout (in seconds) used in the context passed to save
+func SaveTimeout(saveTimeout int) Option {
+	return func(s *Store) {
+		s.saveTimeout = saveTimeout
+	}
+}

--- a/options.go
+++ b/options.go
@@ -122,8 +122,8 @@ func RefreshCookies() Option {
 }
 
 // SaveTimeout sets the timeout (in seconds) used in the context passed to save
-func SaveTimeout(saveTimeout int) Option {
+func SaveTimeout(t int) Option {
 	return func(s *Store) {
-		s.saveTimeout = saveTimeout
+		s.saveTimeout = t
 	}
 }


### PR DESCRIPTION
### Summary
Uses a new context in requests to save a session instead of the request context. In my use case, this will help ensure that the the context used in save requests is not cancelled further up the chain and has a predictable timeout.

### Changes
- New saveTimeout (int) option on Store (default is 1)
- New SaveTimeout() Option that when provided will set the saveTimeout option on the store